### PR TITLE
WeakValueProxy

### DIFF
--- a/Sources/DidUpdate/Observers/StateValueObserver.swift
+++ b/Sources/DidUpdate/Observers/StateValueObserver.swift
@@ -1,4 +1,4 @@
-/// Opaque observer object, removing the its observer from the `StateObserver` when deallocated
+/// Opaque observer object, removing its observer from the `StateObserver` when deallocated
 public struct StateValueObserver {
 	private var observer: AnyObject
 

--- a/Sources/DidUpdate/Property Wrappers/ObservedValue.swift
+++ b/Sources/DidUpdate/Property Wrappers/ObservedValue.swift
@@ -38,10 +38,8 @@ public struct ObservedValue<Value> {
 		storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Self>
 	) -> ReadOnlyProxy<Value> {
 		get {
-			return ReadOnlyProxy(
-				get: {
-					instance[keyPath: storageKeyPath].storage
-				},
+			ReadOnlyProxy(
+				get: { instance[keyPath: storageKeyPath].storage },
 				updateHandler: { instance.addObserver(keyPath: storageKeyPath, handler: $0) }
 			)
 		}

--- a/Sources/DidUpdate/Property Wrappers/ValueProxy.swift
+++ b/Sources/DidUpdate/Property Wrappers/ValueProxy.swift
@@ -1,4 +1,4 @@
-/// Forwards value getting and setting to its originating ``ObservableState`` class, wrapped by a ``ObservedState`` property wrapper,
+/// Forwards value getting and setting to its originating ``ObservableState`` class, wrapped by an ``ObservedState`` property wrapper,
 /// and provides the functionality to subscribe to value updates through methods like ``UpdateObservable/didUpdate(withCurrent:handler:)-3mf14``
 @propertyWrapper @dynamicMemberLookup
 public struct ValueProxy<Value>: UpdateObservable {

--- a/Sources/DidUpdate/Property Wrappers/WeakValueProxy.swift
+++ b/Sources/DidUpdate/Property Wrappers/WeakValueProxy.swift
@@ -1,0 +1,72 @@
+/// Forwards value getting and setting to a weakly referenced originating ``ObservableState`` class, wrapped by an ``ObservedState`` property wrapper,
+/// and provides the functionality to subscribe to value updates through methods like ``UpdateObservable/didUpdate(withCurrent:handler:)-3mf14``
+@propertyWrapper @dynamicMemberLookup
+public class WeakValueProxy<Value>: UpdateObservable {
+	let get: () -> Value?
+	let set: (Value) -> Void
+	let updateHandler: (UpdateHandler<Value>) -> StateValueObserver?
+
+	var currentValue: Value
+
+	public var wrappedValue: Value {
+		get {
+			if let value = get() {
+				currentValue = value
+				return value
+			}
+			return currentValue
+		}
+		set {
+			currentValue = newValue
+			set(newValue)
+		}
+	}
+
+	public var projectedValue: WeakValueProxy<Value> { self }
+
+	init(
+		currentValue: Value,
+		get: @escaping () -> Value?,
+		set: @escaping (Value) -> Void,
+		updateHandler: @escaping(UpdateHandler<Value>) -> StateValueObserver?
+	) {
+		self.get = get
+		self.set = set
+		self.updateHandler = updateHandler
+		self.currentValue = currentValue
+	}
+
+	public subscript<Subject>(
+		dynamicMember keyPath: WritableKeyPath<Value, Subject>
+	) -> WeakValueProxy<Subject> {
+		WeakValueProxy<Subject>(self, keyPath: keyPath)
+	}
+}
+
+extension WeakValueProxy {
+	public func addUpdateHandler(_ handler: UpdateHandler<Value>) -> StateValueObserver {
+		let observer = updateHandler(handler)
+		if let observer {
+			return observer
+		}
+		print("Can’t add handler for released ObservableState object, change handler won’t be called other than with current value")
+		if handler.updateWithCurrentValue {
+			handler.handle(update: .current(value: currentValue))
+		}
+		let emptyObserver = StateObserver.Observer(keyPath: \Self.currentValue, handler: handler)
+		return StateValueObserver(emptyObserver)
+	}
+}
+
+extension WeakValueProxy {
+	convenience init<RootValue>(_ proxy: WeakValueProxy<RootValue>, keyPath: WritableKeyPath<RootValue, Value>) {
+		self.init(
+			currentValue: proxy.currentValue[keyPath: keyPath],
+			get: { proxy.wrappedValue[keyPath: keyPath] },
+			set: { proxy.wrappedValue[keyPath: keyPath] = $0 },
+			updateHandler: { update in
+				proxy.updateHandler(update.passThrough(from: keyPath))
+			}
+		)
+	}
+}

--- a/Sources/DidUpdate/Protocols/ObservableState.swift
+++ b/Sources/DidUpdate/Protocols/ObservableState.swift
@@ -29,6 +29,28 @@ public struct ObservableValues<StateObject: ObservableState> {
 	}
 }
 
+extension ObservableValues {
+	/// Creates `WeakValueProxy` structs to forward getting and setting of values and allow adding observers for specific keyPaths without strongly retaining the source object
+	@dynamicMemberLookup
+	public struct WeakValues {
+		fileprivate var stateObject: () -> StateObject
+		fileprivate init(observing: @autoclosure @escaping () -> StateObject) {
+			self.stateObject = observing
+		}
+
+		public subscript<Value>(
+			dynamicMember keyPath: ReferenceWritableKeyPath<StateObject, Value>
+		) -> WeakValueProxy<Value> {
+			stateObject().weakValueProxy(from: keyPath)
+		}
+	}
+	
+	/// Creates value proxies that don’t retain the source object so these can be passed through and stored by objects retained by your `ObservableState` class.
+	public var weak: WeakValues {
+		WeakValues(observing: stateObject())
+	}
+}
+
 private let key = malloc(1)!
 
 extension ObservableState {
@@ -43,11 +65,13 @@ extension ObservableState {
 
 	/// Wrapper to create local proxies using dynamic member subscripts
 	/// - Returns: ``ObservableValues`` struct pointing to wrapping self
+	/// - Note: Be mindful of retain cycles when passing a `ValueProxy` to an object retained by this class, as these proxies strongly capture `self`.
+	/// Start your dynamic member lookup with `.weak` to create a `WeakValueProxy` to prevent this issue (`observableValues.weak.yourProperty`)
 	public var observableValues: ObservableValues<Self> {
 		ObservableValues(observing: self)
 	}
 
-	func valueProxy<Value>(from keyPath: ReferenceWritableKeyPath<Self, Value>) -> ValueProxy<Value> {
+	fileprivate func valueProxy<Value>(from keyPath: ReferenceWritableKeyPath<Self, Value>) -> ValueProxy<Value> {
 		ValueProxy {
 			self[keyPath: keyPath]
 		} set: { newValue in
@@ -57,11 +81,26 @@ extension ObservableState {
 		}
 	}
 
-	func readonlyProxy<Value>(from keyPath: KeyPath<Self, Value>) -> ReadOnlyProxy<Value> {
+	fileprivate func readonlyProxy<Value>(from keyPath: KeyPath<Self, Value>) -> ReadOnlyProxy<Value> {
 		ReadOnlyProxy {
 			self[keyPath: keyPath]
 		} updateHandler: { handler in
 			self.addObserver(keyPath: keyPath, handler: handler)
 		}
+	}
+
+	fileprivate func weakValueProxy<Value>(from keyPath: ReferenceWritableKeyPath<Self, Value>) -> WeakValueProxy<Value> {
+		WeakValueProxy(
+			currentValue: self[keyPath: keyPath],
+			get: { [weak self] in
+				self?[keyPath: keyPath]
+			},
+			set: { [weak self] newValue in
+				self?[keyPath: keyPath] = newValue
+			},
+			updateHandler: { [weak self] handler in
+				self?.addObserver(keyPath: keyPath, handler: handler)
+			}
+		)
 	}
 }

--- a/Sources/DidUpdate/Protocols/ObservableState.swift
+++ b/Sources/DidUpdate/Protocols/ObservableState.swift
@@ -11,7 +11,7 @@ public protocol ObservableState: AnyObject {
 @dynamicMemberLookup
 public struct ObservableValues<StateObject: ObservableState> {
 	fileprivate var stateObject: () -> StateObject
-	public init(observing: @autoclosure @escaping () -> StateObject) {
+	fileprivate init(observing: @autoclosure @escaping () -> StateObject) {
 		self.stateObject = observing
 	}
 


### PR DESCRIPTION
Solution to be able to use value proxies with classes retained by an `ObservableState` object without introducing a retain cycle. Create a `WeakValueProxy` by starting with `.weak` when passing through an observable value:
```swift
lazy var someRetainedObject = YourObject(property: observableValues.weak.yourProperty)
```